### PR TITLE
usbdrv: support HID descriptors over 255 bytes

### DIFF
--- a/usbdrv/usbdrv.c
+++ b/usbdrv/usbdrv.c
@@ -169,7 +169,8 @@ PROGMEM const char usbDescriptorConfiguration[] = {    /* USB configuration desc
     0x00,       /* target country code */
     0x01,       /* number of HID Report (or other HID class) Descriptor infos to follow */
     0x22,       /* descriptor type: report */
-    USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH, 0,  /* total length of report descriptor */
+    (USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH & 0xFF), /* descriptor length (low byte) */
+    ((USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH >> 8) & 0xFF), /*            (high byte) */
 #endif
 #if USB_CFG_HAVE_INTRIN_ENDPOINT    /* endpoint descriptor for endpoint 1 */
     7,          /* sizeof(usbDescrEndpoint) */


### PR DESCRIPTION
Implementing HID devices conforming to the Windows 8 Sensor API can produce quite large
HID descriptors - well over 255 bytes. This requires USB_CFG_LONG_TRANSFERS to be enabled
and also requires the recent patch to support large descriptors. That patch failed to enable
large HID descriptors but this is fixed by this commit.

Signed-off-by: Pat Thoyts patthoyts@users.sourceforge.net
