### PR TITLE
g++ warning fixes

### DIFF
--- a/usbdrv/asmcommon.inc
+++ b/usbdrv/asmcommon.inc
@@ -14,7 +14,7 @@
 /*
 General Description:
 This file contains assembler code which is shared among the USB driver
-implementations for different CPU cocks. Since the code must be inserted
+implementations for different CPU clocks. Since the code must be inserted
 in the middle of the module, it's split out into this file and #included.
 
 Jump destinations called from outside:

--- a/usbdrv/usbdrv.h
+++ b/usbdrv/usbdrv.h
@@ -260,7 +260,7 @@ USB_PUBLIC void usbSetInterrupt3(uchar *data, uchar len);
 /* Same as above for endpoint 3 */
 #endif
 #endif /* USB_CFG_HAVE_INTRIN_ENDPOINT */
-#if USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH    /* simplified interface for backward compatibility */
+#if defined USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH    /* simplified interface for backward compatibility */
 #define usbHidReportDescriptor  usbDescriptorHidReport
 /* should be declared as: PROGMEM char usbHidReportDescriptor[]; */
 /* If you implement an HID device, you need to provide a report descriptor.
@@ -458,7 +458,7 @@ extern volatile schar   usbRxLen;
 #endif
 #if !(USB_CFG_DESCR_PROPS_HID_REPORT)
 #   undef USB_CFG_DESCR_PROPS_HID_REPORT
-#   if USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH /* do some backward compatibility tricks */
+#   if defined USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH /* do some backward compatibility tricks */
 #       define USB_CFG_DESCR_PROPS_HID_REPORT       USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH
 #   else
 #       define USB_CFG_DESCR_PROPS_HID_REPORT       0

--- a/usbdrv/usbdrvasm128.inc
+++ b/usbdrv/usbdrvasm128.inc
@@ -27,10 +27,10 @@ Although it may seem very handy to save the crystal and use the internal
 RC oscillator of the CPU, this method (and this module) has some serious
 limitations:
 (1) The guaranteed calibration range of the oscillator is only 8.1 MHz.
-They typical range is 14.5 MHz and most AVRs can actually reach this rate.
+The typical range is 14.5 MHz and most AVRs can actually reach this rate.
 (2) Writing EEPROM and Flash may be unreliable (short data lifetime) since
 the write procedure is timed from the RC oscillator.
-(3) End Of Packet detection (SE0) should be in bit 1, bit it is only checked
+(3) End Of Packet detection (SE0) should be in bit 1, but it is only checked
 if bits 0 and 1 both read as 0 on D- and D+ read as 0 in the middle. This may
 cause problems with old hubs which delay SE0 by up to one cycle.
 (4) Code size is much larger than that of the other modules.

--- a/usbdrv/usbportability.h
+++ b/usbdrv/usbportability.h
@@ -81,7 +81,7 @@ Thanks to Oleg Semyonov for his help with the IAR tools port!
  */
 
 /* ------------------------------------------------------------------------- */
-#elif __CODEVISIONAVR__ /* check for CodeVision AVR */
+#elif defined __CODEVISIONAVR__ /* check for CodeVision AVR */
 /* ------------------------------------------------------------------------- */
 /* This port is not working (yet) */
 


### PR DESCRIPTION
Fixed comment typos and macro #if tests that g++ was complaining about, it complains if SOMETHING isn't defined such as '#if SOMETHING'

v-usb has been working on my project and I haven't had any USB problems.