### PR TITLE
Update to libusb-1.0

### DIFF
--- a/examples/custom-class/commandline/set-led.c
+++ b/examples/custom-class/commandline/set-led.c
@@ -20,7 +20,7 @@ respectively.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <usb.h>        /* this is libusb */
+#include <libusb.h>        /* this is libusb */
 #include "opendevice.h" /* common code moved to separate module */
 
 #include "../firmware/requests.h"   /* custom request numbers */
@@ -87,7 +87,7 @@ int                 cnt, vid, pid, isOn, r;
 #endif
 
     if(strcasecmp(argv[1], "status") == 0){
-        cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | USB_ENDPOINT_IN, CUSTOM_RQ_GET_STATUS, 0, 0, (unsigned char *)buffer, sizeof(buffer), 5000);
+        cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | LIBUSB_ENDPOINT_IN, CUSTOM_RQ_GET_STATUS, 0, 0, (unsigned char *)buffer, sizeof(buffer), 5000);
         if(cnt < 1){
             if(cnt < 0){
                 fprintf(stderr, "USB error: %s\n", libusb_strerror(cnt));
@@ -98,7 +98,7 @@ int                 cnt, vid, pid, isOn, r;
             printf("LED is %s\n", buffer[0] ? "on" : "off");
         }
     }else if((isOn = (strcasecmp(argv[1], "on") == 0)) || strcasecmp(argv[1], "off") == 0){
-        cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | USB_ENDPOINT_OUT, CUSTOM_RQ_SET_STATUS, isOn, 0, (unsigned char *)buffer, 0, 5000);
+        cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | LIBUSB_ENDPOINT_OUT, CUSTOM_RQ_SET_STATUS, isOn, 0, (unsigned char *)buffer, 0, 5000);
         if(cnt < 0){
             fprintf(stderr, "USB error: %s\n", libusb_strerror(cnt));
         }

--- a/examples/custom-class/commandline/set-led.c
+++ b/examples/custom-class/commandline/set-led.c
@@ -39,13 +39,17 @@ static void usage(char *name)
 
 int main(int argc, char **argv)
 {
-usb_dev_handle      *handle = NULL;
+libusb_device_handle      *handle = NULL;
 const unsigned char rawVid[2] = {USB_CFG_VENDOR_ID}, rawPid[2] = {USB_CFG_DEVICE_ID};
 char                vendor[] = {USB_CFG_VENDOR_NAME, 0}, product[] = {USB_CFG_DEVICE_NAME, 0};
 char                buffer[4];
-int                 cnt, vid, pid, isOn;
+int                 cnt, vid, pid, isOn, r;
 
-    usb_init();
+    r = libusb_init(NULL);
+    if (0 != r) {
+        fprintf(stderr, "Warning: cannot initialize libusb: %s\n", libusb_strerror(r));
+        exit(1);
+    }
     if(argc < 2){   /* we need at least one argument */
         usage(argv[0]);
         exit(1);
@@ -66,25 +70,27 @@ int                 cnt, vid, pid, isOn;
      * needs it: */
 #if 0
     int retries = 1, usbConfiguration = 1, usbInterface = 0;
-    if(usb_set_configuration(handle, usbConfiguration) && showWarnings){
-        fprintf(stderr, "Warning: could not set configuration: %s\n", usb_strerror());
+    r = libusb_set_configuration(handle, usbConfiguration);
+    if(r != 0 && showWarnings){
+        fprintf(stderr, "Warning: could not set configuration: %s\n", libusb_strerror(r));
     }
     /* now try to claim the interface and detach the kernel HID driver on
      * Linux and other operating systems which support the call. */
-    while((len = usb_claim_interface(handle, usbInterface)) != 0 && retries-- > 0){
+    while((len = libusb_claim_interface(handle, usbInterface)) != 0 && retries-- > 0){
 #ifdef LIBUSB_HAS_DETACH_KERNEL_DRIVER_NP
-        if(usb_detach_kernel_driver_np(handle, 0) < 0 && showWarnings){
-            fprintf(stderr, "Warning: could not detach kernel driver: %s\n", usb_strerror());
+        r = libusb_detach_kernel_driver(handle, 0);
+        if(r != 0 && showWarnings){
+            fprintf(stderr, "Warning: could not detach kernel driver: %s\n", libusb_strerror(r));
         }
 #endif
     }
 #endif
 
     if(strcasecmp(argv[1], "status") == 0){
-        cnt = usb_control_msg(handle, USB_TYPE_VENDOR | USB_RECIP_DEVICE | USB_ENDPOINT_IN, CUSTOM_RQ_GET_STATUS, 0, 0, buffer, sizeof(buffer), 5000);
+        cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | USB_ENDPOINT_IN, CUSTOM_RQ_GET_STATUS, 0, 0, (unsigned char *)buffer, sizeof(buffer), 5000);
         if(cnt < 1){
             if(cnt < 0){
-                fprintf(stderr, "USB error: %s\n", usb_strerror());
+                fprintf(stderr, "USB error: %s\n", libusb_strerror(cnt));
             }else{
                 fprintf(stderr, "only %d bytes received.\n", cnt);
             }
@@ -92,9 +98,9 @@ int                 cnt, vid, pid, isOn;
             printf("LED is %s\n", buffer[0] ? "on" : "off");
         }
     }else if((isOn = (strcasecmp(argv[1], "on") == 0)) || strcasecmp(argv[1], "off") == 0){
-        cnt = usb_control_msg(handle, USB_TYPE_VENDOR | USB_RECIP_DEVICE | USB_ENDPOINT_OUT, CUSTOM_RQ_SET_STATUS, isOn, 0, buffer, 0, 5000);
+        cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | USB_ENDPOINT_OUT, CUSTOM_RQ_SET_STATUS, isOn, 0, (unsigned char *)buffer, 0, 5000);
         if(cnt < 0){
-            fprintf(stderr, "USB error: %s\n", usb_strerror());
+            fprintf(stderr, "USB error: %s\n", libusb_strerror(cnt));
         }
 #if ENABLE_TEST
     }else if(strcasecmp(argv[1], "test") == 0){
@@ -107,9 +113,9 @@ int                 cnt, vid, pid, isOn;
                 fprintf(stderr, "\r%05d", i+1);
                 fflush(stderr);
             }
-            cnt = usb_control_msg(handle, USB_TYPE_VENDOR | USB_RECIP_DEVICE | USB_ENDPOINT_IN, CUSTOM_RQ_ECHO, value, index, buffer, sizeof(buffer), 5000);
+            cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | USB_ENDPOINT_IN, CUSTOM_RQ_ECHO, value, index, (unsigned char *)buffer, sizeof(buffer), 5000);
             if(cnt < 0){
-                fprintf(stderr, "\nUSB error in iteration %d: %s\n", i, usb_strerror());
+                fprintf(stderr, "\nUSB error in iteration %d: %s\n", i, libusb_strerror(cnt));
                 break;
             }else if(cnt != 4){
                 fprintf(stderr, "\nerror in iteration %d: %d bytes received instead of 4\n", i, cnt);
@@ -129,6 +135,6 @@ int                 cnt, vid, pid, isOn;
         usage(argv[0]);
         exit(1);
     }
-    usb_close(handle);
+    libusb_close(handle);
     return 0;
 }

--- a/examples/drivertest/commandline/runtest.c
+++ b/examples/drivertest/commandline/runtest.c
@@ -13,6 +13,7 @@ General Description:
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <usb.h>        /* this is libusb */
 #include "opendevice.h" /* common code moved to separate module */
 
@@ -111,7 +112,11 @@ int             cnt, vid, pid, i, j;
             }
         }
     }else{
+#ifdef __linux__
+        srandom(time(NULL));
+#else
         srandomdev();
+#endif
         for(i = 0; i <= 100000; i++){
             fillBuffer(txBuffer, sizeof(txBuffer));
             cnt = usb_control_msg(handle, USB_TYPE_VENDOR | USB_RECIP_DEVICE | USB_ENDPOINT_OUT, CUSTOM_RQ_SET_DATA, 0, 0, txBuffer, sizeof(txBuffer), 5000);

--- a/examples/drivertest/commandline/runtest.c
+++ b/examples/drivertest/commandline/runtest.c
@@ -80,13 +80,17 @@ int i, rval = 0;
 
 int main(int argc, char **argv)
 {
-usb_dev_handle  *handle = NULL;
+libusb_device_handle  *handle = NULL;
 const uchar     rawVid[2] = {USB_CFG_VENDOR_ID}, rawPid[2] = {USB_CFG_DEVICE_ID};
 char            vendor[] = {USB_CFG_VENDOR_NAME, 0}, product[] = {USB_CFG_DEVICE_NAME, 0};
 char            txBuffer[64], rxBuffer[64];
-int             cnt, vid, pid, i, j;
+int             cnt, vid, pid, i, j, r;
 
-    usb_init();
+    r = libusb_init(NULL);
+    if (0 != r) {
+        fprintf(stderr, "Warning: cannot initialize libusb: %s\n", libusb_strerror(r));
+        exit(1);
+    }
     /* compute VID/PID from usbconfig.h so that there is a central source of information */
     vid = rawVid[1] * 256 + rawVid[0];
     pid = rawPid[1] * 256 + rawPid[0];
@@ -99,14 +103,14 @@ int             cnt, vid, pid, i, j;
         if(argc > 2){   /* set osccal */
             int osccal = atoi(argv[2]);
             printf("setting osccal to %d\n", osccal);
-            cnt = usb_control_msg(handle, USB_TYPE_VENDOR | USB_RECIP_DEVICE | USB_ENDPOINT_IN, CUSTOM_RQ_SET_OSCCAL, osccal, 0, txBuffer, 0, 5000);
+            cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | USB_ENDPOINT_IN, CUSTOM_RQ_SET_OSCCAL, osccal, 0, (unsigned char *)txBuffer, 0, 5000);
             if(cnt < 0){
-                fprintf(stderr, "\nUSB error setting osccal: %s\n", usb_strerror());
+                fprintf(stderr, "\nUSB error setting osccal: %s\n", libusb_strerror(cnt));
             }
         }else{
-            cnt = usb_control_msg(handle, USB_TYPE_VENDOR | USB_RECIP_DEVICE | USB_ENDPOINT_IN, CUSTOM_RQ_GET_OSCCAL, 0, 0, rxBuffer, 1, 5000);
+            cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | USB_ENDPOINT_IN, CUSTOM_RQ_GET_OSCCAL, 0, 0, (unsigned char *)rxBuffer, 1, 5000);
             if(cnt < 0){
-                fprintf(stderr, "\nUSB error getting osccal: %s\n", usb_strerror());
+                fprintf(stderr, "\nUSB error getting osccal: %s\n", libusb_strerror(cnt));
             }else{
                 printf("osccal = %d\n", (unsigned char)rxBuffer[0]);
             }
@@ -119,9 +123,9 @@ int             cnt, vid, pid, i, j;
 #endif
         for(i = 0; i <= 100000; i++){
             fillBuffer(txBuffer, sizeof(txBuffer));
-            cnt = usb_control_msg(handle, USB_TYPE_VENDOR | USB_RECIP_DEVICE | USB_ENDPOINT_OUT, CUSTOM_RQ_SET_DATA, 0, 0, txBuffer, sizeof(txBuffer), 5000);
+            cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | USB_ENDPOINT_OUT, CUSTOM_RQ_SET_DATA, 0, 0, (unsigned char *)txBuffer, sizeof(txBuffer), 5000);
             if(cnt < 0){
-                fprintf(stderr, "\nUSB tx error in iteration %d: %s\n", i, usb_strerror());
+                fprintf(stderr, "\nUSB tx error in iteration %d: %s\n", i, libusb_strerror(cnt));
                 break;
             }else if(cnt != sizeof(txBuffer)){
                 fprintf(stderr, "\nerror in iteration %d: %d bytes sent instead of %d\n", i, cnt, (int)sizeof(txBuffer));
@@ -130,9 +134,9 @@ int             cnt, vid, pid, i, j;
             for(j = 0; j < sizeof(rxBuffer); j++){
                 rxBuffer[j] = ~txBuffer[j];
             }
-            cnt = usb_control_msg(handle, USB_TYPE_VENDOR | USB_RECIP_DEVICE | USB_ENDPOINT_IN, CUSTOM_RQ_GET_DATA, 0, 0, rxBuffer, sizeof(rxBuffer), 5000);
+            cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | USB_ENDPOINT_IN, CUSTOM_RQ_GET_DATA, 0, 0, (unsigned char *)rxBuffer, sizeof(rxBuffer), 5000);
             if(cnt < 0){
-                fprintf(stderr, "\nUSB rx error in iteration %d: %s\n", i, usb_strerror());
+                fprintf(stderr, "\nUSB rx error in iteration %d: %s\n", i, libusb_strerror(cnt));
                 break;
             }else if(cnt != sizeof(txBuffer)){
                 fprintf(stderr, "\nerror in iteration %d: %d bytes received instead of %d\n", i, cnt, (int)sizeof(rxBuffer));
@@ -151,6 +155,6 @@ int             cnt, vid, pid, i, j;
         }
         fprintf(stderr, "\nTest completed.\n");
     }
-    usb_close(handle);
+    libusb_close(handle);
     return 0;
 }

--- a/examples/drivertest/commandline/runtest.c
+++ b/examples/drivertest/commandline/runtest.c
@@ -14,7 +14,7 @@ General Description:
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <usb.h>        /* this is libusb */
+#include <libusb.h>        /* this is libusb */
 #include "opendevice.h" /* common code moved to separate module */
 
 #include "../firmware/requests.h"   /* custom request numbers */
@@ -103,12 +103,12 @@ int             cnt, vid, pid, i, j, r;
         if(argc > 2){   /* set osccal */
             int osccal = atoi(argv[2]);
             printf("setting osccal to %d\n", osccal);
-            cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | USB_ENDPOINT_IN, CUSTOM_RQ_SET_OSCCAL, osccal, 0, (unsigned char *)txBuffer, 0, 5000);
+            cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | LIBUSB_ENDPOINT_IN, CUSTOM_RQ_SET_OSCCAL, osccal, 0, (unsigned char *)txBuffer, 0, 5000);
             if(cnt < 0){
                 fprintf(stderr, "\nUSB error setting osccal: %s\n", libusb_strerror(cnt));
             }
         }else{
-            cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | USB_ENDPOINT_IN, CUSTOM_RQ_GET_OSCCAL, 0, 0, (unsigned char *)rxBuffer, 1, 5000);
+            cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | LIBUSB_ENDPOINT_IN, CUSTOM_RQ_GET_OSCCAL, 0, 0, (unsigned char *)rxBuffer, 1, 5000);
             if(cnt < 0){
                 fprintf(stderr, "\nUSB error getting osccal: %s\n", libusb_strerror(cnt));
             }else{
@@ -123,7 +123,7 @@ int             cnt, vid, pid, i, j, r;
 #endif
         for(i = 0; i <= 100000; i++){
             fillBuffer(txBuffer, sizeof(txBuffer));
-            cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | USB_ENDPOINT_OUT, CUSTOM_RQ_SET_DATA, 0, 0, (unsigned char *)txBuffer, sizeof(txBuffer), 5000);
+            cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | LIBUSB_ENDPOINT_OUT, CUSTOM_RQ_SET_DATA, 0, 0, (unsigned char *)txBuffer, sizeof(txBuffer), 5000);
             if(cnt < 0){
                 fprintf(stderr, "\nUSB tx error in iteration %d: %s\n", i, libusb_strerror(cnt));
                 break;
@@ -134,7 +134,7 @@ int             cnt, vid, pid, i, j, r;
             for(j = 0; j < sizeof(rxBuffer); j++){
                 rxBuffer[j] = ~txBuffer[j];
             }
-            cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | USB_ENDPOINT_IN, CUSTOM_RQ_GET_DATA, 0, 0, (unsigned char *)rxBuffer, sizeof(rxBuffer), 5000);
+            cnt = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | LIBUSB_ENDPOINT_IN, CUSTOM_RQ_GET_DATA, 0, 0, (unsigned char *)rxBuffer, sizeof(rxBuffer), 5000);
             if(cnt < 0){
                 fprintf(stderr, "\nUSB rx error in iteration %d: %s\n", i, libusb_strerror(cnt));
                 break;

--- a/examples/hid-data/commandline/Makefile
+++ b/examples/hid-data/commandline/Makefile
@@ -10,16 +10,14 @@
 # system:
 
 # Use the following 3 lines on Unix and Mac OS X:
-#USBFLAGS=   `libusb-config --cflags`
-#USBLIBS=    `libusb-config --libs`
 USBFLAGS=   `pkg-config --cflags libusb-1.0`
 USBLIBS=    `pkg-config --libs libusb-1.0`
 EXE_SUFFIX=
 
 # Use the following 3 lines on Windows and comment out the 3 above:
-#USBFLAGS=
-#USBLIBS=    -lhid -lusb -lsetupapi
-#EXE_SUFFIX= .exe
+#USBFLAGS = -I/usr/local/include/libusb-1.0
+#USBLIBS = -L/usr/local/lib -lhid -lusb-1.0 -lsetupapi
+#EXE_SUFFIX = .exe
 
 CC=				gcc
 CFLAGS=			-O -Wall $(USBFLAGS)

--- a/examples/hid-data/commandline/Makefile
+++ b/examples/hid-data/commandline/Makefile
@@ -10,8 +10,10 @@
 # system:
 
 # Use the following 3 lines on Unix and Mac OS X:
-USBFLAGS=   `libusb-config --cflags`
-USBLIBS=    `libusb-config --libs`
+#USBFLAGS=   `libusb-config --cflags`
+#USBLIBS=    `libusb-config --libs`
+USBFLAGS=   `pkg-config --cflags libusb-1.0`
+USBLIBS=    `pkg-config --libs libusb-1.0`
 EXE_SUFFIX=
 
 # Use the following 3 lines on Windows and comment out the 3 above:

--- a/examples/hid-data/commandline/Makefile.windows
+++ b/examples/hid-data/commandline/Makefile.windows
@@ -12,6 +12,6 @@
 
 include Makefile
 
-USBFLAGS=
-USBLIBS=    -lhid -lsetupapi
+USBFLAGS = -I/usr/local/mingw/include/libusb-1.0
+USBLIBS = -L/usr/local/mingw/lib -lhid -lusb-1.0 -lsetupapi
 EXE_SUFFIX= .exe

--- a/examples/usbtool/Makefile
+++ b/examples/usbtool/Makefile
@@ -11,16 +11,14 @@
 # This Makefile has been tested on Mac OS X, Linux and Windows.
 
 # Use the following 3 lines on Unix (uncomment the framework on Mac OS X):
-#USBFLAGS = `libusb-config --cflags`
-#USBLIBS = `libusb-config --libs`
 USBFLAGS = `pkg-config --cflags libusb-1.0`
 USBLIBS = `pkg-config --libs libusb-1.0`
 EXE_SUFFIX =
 
 # Use the following 3 lines on Windows and comment out the 3 above. You may
 # have to change the include paths to where you installed libusb-win32
-#USBFLAGS = -I/usr/local/include
-#USBLIBS = -L/usr/local/lib -lusb
+#USBFLAGS = -I/usr/local/include/libusb-1.0
+#USBLIBS = -L/usr/local/lib -lusb-1.0
 #EXE_SUFFIX = .exe
 
 NAME = usbtool

--- a/examples/usbtool/Makefile
+++ b/examples/usbtool/Makefile
@@ -11,8 +11,10 @@
 # This Makefile has been tested on Mac OS X, Linux and Windows.
 
 # Use the following 3 lines on Unix (uncomment the framework on Mac OS X):
-USBFLAGS = `libusb-config --cflags`
-USBLIBS = `libusb-config --libs`
+#USBFLAGS = `libusb-config --cflags`
+#USBLIBS = `libusb-config --libs`
+USBFLAGS = `pkg-config --cflags libusb-1.0`
+USBLIBS = `pkg-config --libs libusb-1.0`
 EXE_SUFFIX =
 
 # Use the following 3 lines on Windows and comment out the 3 above. You may

--- a/examples/usbtool/Makefile.windows
+++ b/examples/usbtool/Makefile.windows
@@ -12,6 +12,6 @@
 
 include Makefile
 
-USBFLAGS = -I/usr/local/mingw/include
-USBLIBS = -L/usr/local/mingw/lib -lusb
+USBFLAGS = -I/usr/local/mingw/include/libusb-1.0
+USBLIBS = -L/usr/local/mingw/lib -lusb-1.0
 EXE_SUFFIX = .exe

--- a/examples/usbtool/usbtool.c
+++ b/examples/usbtool/usbtool.c
@@ -296,7 +296,7 @@ FILE            *fp;
          */
         while((len = libusb_claim_interface(handle, usbInterface)) != 0 && retries-- > 0){
 #ifdef LIBUSB_HAS_DETACH_KERNEL_DRIVER_NP
-            r = usb_detach_kernel_driver(handle, 0);
+            r = libusb_detach_kernel_driver(handle, 0);
             if(r != LIBUSB_SUCCESS && showWarnings){
                 fprintf(stderr, "Warning: could not detach kernel driver: %s\n", libusb_strerror(r));
             }

--- a/examples/usbtool/usbtool.c
+++ b/examples/usbtool/usbtool.c
@@ -25,7 +25,7 @@ On Windows use libusb-win32 from http://libusb-win32.sourceforge.net/.
 #include <ctype.h>
 #include <errno.h>
 
-#include <usb.h>        /* this is libusb, see http://libusb.sourceforge.net/ */
+#include <libusb.h>        /* this is libusb, see http://libusb.sourceforge.net/ */
 #include "opendevice.h" /* common code moved to separate module */
 
 #define DEFAULT_USB_VID         0   /* any */
@@ -147,8 +147,9 @@ int     i, numEntries;
 
 int main(int argc, char **argv)
 {
-usb_dev_handle  *handle = NULL;
+libusb_device_handle  *handle = NULL;
 int             opt, len, action, argcnt;
+int             r = 0;
 char            *myName = argv[0], *s, *rxBuffer = NULL;
 FILE            *fp;
 
@@ -260,7 +261,7 @@ FILE            *fp;
     if(argc > argcnt){
         fprintf(stderr, "Warning: only %d arguments expected, rest ignored.\n", argcnt);
     }
-    usb_init();
+    libusb_init(NULL);
     if(usbOpenDevice(&handle, vendorID, vendorNamePattern, productID, productNamePattern, serialPattern, action == ACTION_LIST ? stdout : NULL, showWarnings ? stderr : NULL) != 0){
         fprintf(stderr, "Could not find USB device with VID=0x%x PID=0x%x Vname=%s Pname=%s Serial=%s\n", vendorID, productID, vendorNamePattern, productNamePattern, serialPattern);
         exit(1);
@@ -280,43 +281,45 @@ FILE            *fp;
         usbIndex = myAtoi(argv[6]);
         requestType = ((usbDirection & 1) << 7) | ((usbType & 3) << 5) | (usbRecipient & 0x1f);
         if(usbDirection){   /* IN transfer */
-            len = usb_control_msg(handle, requestType, usbRequest, usbValue, usbIndex, rxBuffer, usbCount, usbTimeout);
+            len = libusb_control_transfer(handle, requestType, usbRequest, usbValue, usbIndex, (unsigned char *)rxBuffer, usbCount, usbTimeout);
         }else{              /* OUT transfer */
-            len = usb_control_msg(handle, requestType, usbRequest, usbValue, usbIndex, sendBytes, sendByteCount, usbTimeout);
+            len = libusb_control_transfer(handle, requestType, usbRequest, usbValue, usbIndex, (unsigned char *)sendBytes, sendByteCount, usbTimeout);
         }
     }else{  /* must be ACTION_INTERRUPT or ACTION_BULK */
         int retries = 1;
-        if(usb_set_configuration(handle, usbConfiguration) && showWarnings){
-            fprintf(stderr, "Warning: could not set configuration: %s\n", usb_strerror());
+        r = libusb_set_configuration(handle, usbConfiguration);
+        if(r < 0 && showWarnings){
+            fprintf(stderr, "Warning: could not set configuration: %s\n", libusb_strerror(r));
         }
         /* now try to claim the interface and detach the kernel HID driver on
          * linux and other operating systems which support the call.
          */
-        while((len = usb_claim_interface(handle, usbInterface)) != 0 && retries-- > 0){
+        while((len = libusb_claim_interface(handle, usbInterface)) != 0 && retries-- > 0){
 #ifdef LIBUSB_HAS_DETACH_KERNEL_DRIVER_NP
-            if(usb_detach_kernel_driver_np(handle, 0) < 0 && showWarnings){
-                fprintf(stderr, "Warning: could not detach kernel driver: %s\n", usb_strerror());
+            r = usb_detach_kernel_driver(handle, 0);
+            if(r != LIBUSB_SUCCESS && showWarnings){
+                fprintf(stderr, "Warning: could not detach kernel driver: %s\n", libusb_strerror(r));
             }
 #endif
         }
         if(len != 0 && showWarnings)
-            fprintf(stderr, "Warning: could not claim interface: %s\n", usb_strerror());
+            fprintf(stderr, "Warning: could not claim interface: %s\n", libusb_strerror(len));
         if(action == ACTION_INTERRUPT){
             if(usbDirection){   /* IN transfer */
-                len = usb_interrupt_read(handle, endpoint, rxBuffer, usbCount, usbTimeout);
+                r = libusb_interrupt_transfer(handle, endpoint, (unsigned char *)rxBuffer, usbCount, &len, usbTimeout);
             }else{
-                len = usb_interrupt_write(handle, endpoint, sendBytes, sendByteCount, usbTimeout);
+                r = libusb_interrupt_transfer(handle, endpoint, (unsigned char *)sendBytes, sendByteCount, &len, usbTimeout);
             }
         }else{
             if(usbDirection){   /* IN transfer */
-                len = usb_bulk_read(handle, endpoint, rxBuffer, usbCount, usbTimeout);
+                r = libusb_bulk_transfer(handle, endpoint, (unsigned char *)rxBuffer, usbCount, &len, usbTimeout);
             }else{
-                len = usb_bulk_write(handle, endpoint, sendBytes, sendByteCount, usbTimeout);
+                r = libusb_bulk_transfer(handle, endpoint, (unsigned char *)sendBytes, sendByteCount, &len, usbTimeout);
             }
         }
     }
-    if(len < 0){
-        fprintf(stderr, "USB error: %s\n", usb_strerror());
+    if(r != 0){
+        fprintf(stderr, "USB error: %s\n", libusb_strerror(r));
         exit(1);
     }
     if(usbDirection == 0)   /* OUT */
@@ -348,7 +351,7 @@ FILE            *fp;
                 fprintf(fp, "\n");
         }
     }
-    usb_close(handle);
+    libusb_close(handle);
     if(rxBuffer != NULL)
         free(rxBuffer);
     return 0;

--- a/libs-host/hiddata.c
+++ b/libs-host/hiddata.c
@@ -162,7 +162,7 @@ BOOLEAN rval = 0;
 #include <string.h>
 #include <libusb.h>
 
-#define usbDevice   usb_dev_handle  /* use libusb's device structure */
+#define usbDevice   libusb_device_handle  /* use libusb's device structure */
 
 /* ------------------------------------------------------------------------- */
 
@@ -199,7 +199,7 @@ int usbhidOpenDevice(usbDevice_t **device, int vendor, char *vendorName, int pro
     handle = libusb_open_device_with_vid_pid(NULL, vendor, product);
     if(handle == NULL) {
         errorCode = USBOPEN_ERR_ACCESS;
-        fprintf(stderr, "Warning: cannot open USB device: %s\n", libusb_strerror(r));
+        fprintf(stderr, "Warning: cannot open USB device\n");
         return errorCode;
     }
 

--- a/libs-host/hiddata.c
+++ b/libs-host/hiddata.c
@@ -160,7 +160,7 @@ BOOLEAN rval = 0;
 /* ######################################################################## */
 
 #include <string.h>
-#include <usb.h>
+#include <libusb.h>
 
 #define usbDevice   usb_dev_handle  /* use libusb's device structure */
 
@@ -176,90 +176,67 @@ static int  usesReportIDs;
 
 /* ------------------------------------------------------------------------- */
 
-static int usbhidGetStringAscii(usb_dev_handle *dev, int index, char *buf, int buflen)
-{
-char    buffer[256];
-int     rval, i;
-
-    if((rval = usb_get_string_simple(dev, index, buf, buflen)) >= 0) /* use libusb version if it works */
-        return rval;
-    if((rval = usb_control_msg(dev, USB_ENDPOINT_IN, USB_REQ_GET_DESCRIPTOR, (USB_DT_STRING << 8) + index, 0x0409, buffer, sizeof(buffer), 5000)) < 0)
-        return rval;
-    if(buffer[1] != USB_DT_STRING){
-        *buf = 0;
-        return 0;
-    }
-    if((unsigned char)buffer[0] < rval)
-        rval = (unsigned char)buffer[0];
-    rval /= 2;
-    /* lossy conversion to ISO Latin1: */
-    for(i=1;i<rval;i++){
-        if(i > buflen)              /* destination buffer overflow */
-            break;
-        buf[i-1] = buffer[2 * i];
-        if(buffer[2 * i + 1] != 0)  /* outside of ISO Latin1 range */
-            buf[i-1] = '?';
-    }
-    buf[i-1] = 0;
-    return i-1;
-}
-
 int usbhidOpenDevice(usbDevice_t **device, int vendor, char *vendorName, int product, char *productName, int _usesReportIDs)
 {
-struct usb_bus      *bus;
-struct usb_device   *dev;
-usb_dev_handle      *handle = NULL;
-int                 errorCode = USBOPEN_ERR_NOTFOUND;
-static int          didUsbInit = 0;
+
+    libusb_device       *dev = NULL;
+    libusb_device_handle *handle = NULL;
+    struct libusb_device_descriptor desc;
+    int                 errorCode = USBOPEN_ERR_NOTFOUND;
+    static int          didUsbInit = 0;
+    char    string[256];
+    int                 r;
 
     if(!didUsbInit){
-        usb_init();
+        r = libusb_init(NULL);
+        if (0 != r) {
+            fprintf(stderr, "Warning: cannot initialize libusb: %s\n", libusb_strerror(r));
+            return errorCode;
+        }
         didUsbInit = 1;
     }
-    usb_find_busses();
-    usb_find_devices();
-    for(bus=usb_get_busses(); bus; bus=bus->next){
-        for(dev=bus->devices; dev; dev=dev->next){
-            if(dev->descriptor.idVendor == vendor && dev->descriptor.idProduct == product){
-                char    string[256];
-                int     len;
-                handle = usb_open(dev); /* we need to open the device in order to query strings */
-                if(!handle){
-                    errorCode = USBOPEN_ERR_ACCESS;
-                    fprintf(stderr, "Warning: cannot open USB device: %s\n", usb_strerror());
-                    continue;
-                }
-                if(vendorName == NULL && productName == NULL){  /* name does not matter */
-                    break;
-                }
-                /* now check whether the names match: */
-                len = usbhidGetStringAscii(handle, dev->descriptor.iManufacturer, string, sizeof(string));
-                if(len < 0){
-                    errorCode = USBOPEN_ERR_IO;
-                    fprintf(stderr, "Warning: cannot query manufacturer for device: %s\n", usb_strerror());
-                }else{
-                    errorCode = USBOPEN_ERR_NOTFOUND;
-                    /* fprintf(stderr, "seen device from vendor ->%s<-\n", string); */
-                    if(strcmp(string, vendorName) == 0){
-                        len = usbhidGetStringAscii(handle, dev->descriptor.iProduct, string, sizeof(string));
-                        if(len < 0){
-                            errorCode = USBOPEN_ERR_IO;
-                            fprintf(stderr, "Warning: cannot query product for device: %s\n", usb_strerror());
-                        }else{
-                            errorCode = USBOPEN_ERR_NOTFOUND;
-                            /* fprintf(stderr, "seen product ->%s<-\n", string); */
-                            if(strcmp(string, productName) == 0)
-                                break;
-                        }
-                    }
-                }
-                usb_close(handle);
-                handle = NULL;
-            }
-        }
-        if(handle)
-            break;
+
+    handle = libusb_open_device_with_vid_pid(NULL, vendor, product);
+    if(handle == NULL) {
+        errorCode = USBOPEN_ERR_ACCESS;
+        fprintf(stderr, "Warning: cannot open USB device: %s\n", libusb_strerror(r));
+        return errorCode;
     }
+
+    dev = libusb_get_device(handle);
+    r = libusb_get_device_descriptor(dev, &desc);
+    if(r < 0) {
+        errorCode = USBOPEN_ERR_IO;
+        fprintf(stderr, "Warning: cannot query descriptor for device: %s\n", libusb_strerror(r));
+        return errorCode;
+    }
+
+    if(vendorName != NULL){
+        r = libusb_get_string_descriptor_ascii(handle, desc.iManufacturer, (unsigned char *)string, sizeof(string));
+        if(r < 0) {
+            errorCode = USBOPEN_ERR_IO;
+            fprintf(stderr, "Warning: cannot query manufacturer for device: %s\n", libusb_strerror(r));
+            return errorCode;
+        }
+        if(strcmp(string, vendorName) != 0){
+            return errorCode;
+        }
+        /* fprintf(stderr, "seen device from vendor ->%s<-\n", string); */
+    }
+
+    if(productName != NULL){
+        r = libusb_get_string_descriptor_ascii(handle, desc.iProduct, (unsigned char *)string, sizeof(string));
+        if(r < 0) {
+            errorCode = USBOPEN_ERR_IO;
+            fprintf(stderr, "Warning: cannot query product for device: %s\n", libusb_strerror(r));
+            return errorCode;
+        }
+        if(strcmp(string, productName) != 0){
+            return errorCode;
+        }
+        /* fprintf(stderr, "seen product ->%s<-\n", string); */
+    }
+
     if(handle != NULL){
         errorCode = 0;
         *device = (void *)handle;
@@ -273,7 +250,7 @@ static int          didUsbInit = 0;
 void    usbhidCloseDevice(usbDevice_t *device)
 {
     if(device != NULL)
-        usb_close((void *)device);
+        libusb_close((void *)device);
 }
 
 /* ------------------------------------------------------------------------- */
@@ -286,10 +263,10 @@ int bytesSent, reportId = buffer[0];
         buffer++;   /* skip dummy report ID */
         len--;
     }
-    bytesSent = usb_control_msg((void *)device, USB_TYPE_CLASS | USB_RECIP_DEVICE | USB_ENDPOINT_OUT, USBRQ_HID_SET_REPORT, USB_HID_REPORT_TYPE_FEATURE << 8 | (reportId & 0xff), 0, buffer, len, 5000);
+    bytesSent = libusb_control_transfer((void *)device, LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_DEVICE | LIBUSB_ENDPOINT_OUT, USBRQ_HID_SET_REPORT, USB_HID_REPORT_TYPE_FEATURE << 8 | (reportId & 0xff), 0, (unsigned char *)buffer, len, 5000);
     if(bytesSent != len){
         if(bytesSent < 0)
-            fprintf(stderr, "Error sending message: %s\n", usb_strerror());
+            fprintf(stderr, "Error sending message: %s\n", libusb_strerror(bytesSent));
         return USBOPEN_ERR_IO;
     }
     return 0;
@@ -305,9 +282,9 @@ int bytesReceived, maxLen = *len;
         buffer++;   /* make room for dummy report ID */
         maxLen--;
     }
-    bytesReceived = usb_control_msg((void *)device, USB_TYPE_CLASS | USB_RECIP_DEVICE | USB_ENDPOINT_IN, USBRQ_HID_GET_REPORT, USB_HID_REPORT_TYPE_FEATURE << 8 | reportNumber, 0, buffer, maxLen, 5000);
+    bytesReceived = libusb_control_transfer((void *)device, LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_DEVICE | LIBUSB_ENDPOINT_IN, USBRQ_HID_GET_REPORT, USB_HID_REPORT_TYPE_FEATURE << 8 | reportNumber, 0, (unsigned char *)buffer, maxLen, 5000);
     if(bytesReceived < 0){
-        fprintf(stderr, "Error sending message: %s\n", usb_strerror());
+        fprintf(stderr, "Error sending message: %s\n", libusb_strerror(bytesReceived));
         return USBOPEN_ERR_IO;
     }
     *len = bytesReceived;

--- a/libs-host/opendevice.c
+++ b/libs-host/opendevice.c
@@ -82,16 +82,17 @@ static int shellStyleMatch(char *text, char *pattern)
 
 /* ------------------------------------------------------------------------- */
 
-int usbGetStringAscii(usb_dev_handle *dev, int index, char *buf, int buflen)
+int usbGetStringAscii(libusb_device_handle *dev, int index, char *buf, int buflen)
 {
 char    buffer[256];
 int     rval, i;
 
-    if((rval = usb_get_string_simple(dev, index, buf, buflen)) >= 0) /* use libusb version if it works */
+    rval = libusb_get_string_descriptor_ascii(dev, index, (unsigned char *)buf, buflen); /* use libusb version if it works */
+    if(rval < 0)
         return rval;
-    if((rval = usb_control_msg(dev, USB_ENDPOINT_IN, USB_REQ_GET_DESCRIPTOR, (USB_DT_STRING << 8) + index, 0x0409, buffer, sizeof(buffer), 5000)) < 0)
+    if((rval = libusb_control_transfer(dev, LIBUSB_ENDPOINT_IN, LIBUSB_REQUEST_GET_DESCRIPTOR, (LIBUSB_DT_STRING << 8) + index, 0, (unsigned char *)buffer, sizeof(buffer), 5000)) < 0)
         return rval;
-    if(buffer[1] != USB_DT_STRING){
+    if(buffer[1] != LIBUSB_DT_STRING){
         *buf = 0;
         return 0;
     }
@@ -112,87 +113,101 @@ int     rval, i;
 
 /* ------------------------------------------------------------------------- */
 
-int usbOpenDevice(usb_dev_handle **device, int vendorID, char *vendorNamePattern, int productID, char *productNamePattern, char *serialNamePattern, FILE *printMatchingDevicesFp, FILE *warningsFp)
+int usbOpenDevice(libusb_device_handle **device, int vendorID, char *vendorNamePattern, int productID, char *productNamePattern, char *serialNamePattern, FILE *printMatchingDevicesFp, FILE *warningsFp)
 {
-struct usb_bus      *bus;
-struct usb_device   *dev;
-usb_dev_handle      *handle = NULL;
-int                 errorCode = USBOPEN_ERR_NOTFOUND;
+    int     errorCode = USBOPEN_ERR_NOTFOUND;
+    struct  libusb_device **devs;
+    struct  libusb_device *dev;
+    struct  libusb_device_handle *dev_handle = NULL;
+    size_t  i = 0;
+    int     r;
 
-    usb_find_busses();
-    usb_find_devices();
-    for(bus = usb_get_busses(); bus; bus = bus->next){
-        for(dev = bus->devices; dev; dev = dev->next){  /* iterate over all devices on all busses */
-            if((vendorID == 0 || dev->descriptor.idVendor == vendorID)
-                        && (productID == 0 || dev->descriptor.idProduct == productID)){
-                char    vendor[256], product[256], serial[256];
-                int     len;
-                handle = usb_open(dev); /* we need to open the device in order to query strings */
-                if(!handle){
-                    errorCode = USBOPEN_ERR_ACCESS;
-                    if(warningsFp != NULL)
-                        fprintf(warningsFp, "Warning: cannot open VID=0x%04x PID=0x%04x: %s\n", dev->descriptor.idVendor, dev->descriptor.idProduct, usb_strerror());
-                    continue;
-                }
-                /* now check whether the names match: */
-                len = vendor[0] = 0;
-                if(dev->descriptor.iManufacturer > 0){
-                    len = usbGetStringAscii(handle, dev->descriptor.iManufacturer, vendor, sizeof(vendor));
-                }
-                if(len < 0){
-                    errorCode = USBOPEN_ERR_ACCESS;
-                    if(warningsFp != NULL)
-                        fprintf(warningsFp, "Warning: cannot query manufacturer for VID=0x%04x PID=0x%04x: %s\n", dev->descriptor.idVendor, dev->descriptor.idProduct, usb_strerror());
-                }else{
-                    errorCode = USBOPEN_ERR_NOTFOUND;
-                    /* printf("seen device from vendor ->%s<-\n", vendor); */
-                    if(shellStyleMatch(vendor, vendorNamePattern)){
-                        len = product[0] = 0;
-                        if(dev->descriptor.iProduct > 0){
-                            len = usbGetStringAscii(handle, dev->descriptor.iProduct, product, sizeof(product));
-                        }
-                        if(len < 0){
-                            errorCode = USBOPEN_ERR_ACCESS;
-                            if(warningsFp != NULL)
-                                fprintf(warningsFp, "Warning: cannot query product for VID=0x%04x PID=0x%04x: %s\n", dev->descriptor.idVendor, dev->descriptor.idProduct, usb_strerror());
-                        }else{
-                            errorCode = USBOPEN_ERR_NOTFOUND;
-                            /* printf("seen product ->%s<-\n", product); */
-                            if(shellStyleMatch(product, productNamePattern)){
-                                len = serial[0] = 0;
-                                if(dev->descriptor.iSerialNumber > 0){
-                                    len = usbGetStringAscii(handle, dev->descriptor.iSerialNumber, serial, sizeof(serial));
-                                }
-                                if(len < 0){
-                                    errorCode = USBOPEN_ERR_ACCESS;
-                                    if(warningsFp != NULL)
-                                        fprintf(warningsFp, "Warning: cannot query serial for VID=0x%04x PID=0x%04x: %s\n", dev->descriptor.idVendor, dev->descriptor.idProduct, usb_strerror());
-                                }
-                                if(shellStyleMatch(serial, serialNamePattern)){
-                                    if(printMatchingDevicesFp != NULL){
-                                        if(serial[0] == 0){
-                                            fprintf(printMatchingDevicesFp, "VID=0x%04x PID=0x%04x vendor=\"%s\" product=\"%s\"\n", dev->descriptor.idVendor, dev->descriptor.idProduct, vendor, product);
-                                        }else{
-                                            fprintf(printMatchingDevicesFp, "VID=0x%04x PID=0x%04x vendor=\"%s\" product=\"%s\" serial=\"%s\"\n", dev->descriptor.idVendor, dev->descriptor.idProduct, vendor, product, serial);
-                                        }
+    r = libusb_get_device_list(NULL, &devs);
+    if (r < 0) {
+        if(warningsFp != NULL)
+            fprintf(warningsFp, "Warning: cannot query device list: %s\n", libusb_strerror(r));
+        return errorCode;
+    }
+
+    while ((dev = devs[i++]) != NULL) {
+        struct libusb_device_descriptor desc;
+        r = libusb_get_device_descriptor(dev, &desc);
+        if (r < 0) {
+            if(warningsFp != NULL)
+                fprintf(warningsFp, "Warning: cannot query device descriptor: %s\n", libusb_strerror(r));
+            goto out;
+        }
+        if ((vendorID == 0 || desc.idVendor == vendorID)
+             && (productID == 0 || desc.idProduct == productID)) {
+            char    vendor[256], product[256], serial[256];
+            int     len;
+
+            r = libusb_open(dev, &dev_handle);
+            if (r < 0) {
+                if(warningsFp != NULL)
+                    fprintf(warningsFp, "Warning: cannot open VID=0x%04x PID=0x%04x: %s\n", desc.idVendor, desc.idProduct, libusb_strerror(r));
+                dev_handle = NULL;
+                continue;
+            }
+            /* now check whether the names match: */
+            len = vendor[0] = 0;
+            if(desc.iManufacturer > 0){
+                len = usbGetStringAscii(dev_handle, desc.iManufacturer, vendor, sizeof(vendor));
+            }
+            if(len < 0){
+                errorCode = USBOPEN_ERR_ACCESS;
+                if(warningsFp != NULL)
+                    fprintf(warningsFp, "Warning: cannot query manufacturer for VID=0x%04x PID=0x%04x: %s\n", desc.idVendor, desc.idProduct, libusb_strerror(len));
+            }else{
+                errorCode = USBOPEN_ERR_NOTFOUND;
+                /* printf("seen device from vendor ->%s<-\n", vendor); */
+                if(shellStyleMatch(vendor, vendorNamePattern)){
+                    len = product[0] = 0;
+                    if(desc.iProduct > 0){
+                        len = usbGetStringAscii(dev_handle, desc.iProduct, product, sizeof(product));
+                    }
+                    if(len < 0){
+                        errorCode = USBOPEN_ERR_ACCESS;
+                        if(warningsFp != NULL)
+                            fprintf(warningsFp, "Warning: cannot query product for VID=0x%04x PID=0x%04x: %s\n", desc.idVendor, desc.idProduct, libusb_strerror(len));
+                    }else{
+                        errorCode = USBOPEN_ERR_NOTFOUND;
+                        /* printf("seen product ->%s<-\n", product); */
+                        if(shellStyleMatch(product, productNamePattern)){
+                            len = serial[0] = 0;
+                            if(desc.iSerialNumber > 0){
+                                len = usbGetStringAscii(dev_handle, desc.iSerialNumber, serial, sizeof(serial));
+                            }
+                            if(len < 0){
+                                errorCode = USBOPEN_ERR_ACCESS;
+                                if(warningsFp != NULL)
+                                    fprintf(warningsFp, "Warning: cannot query serial for VID=0x%04x PID=0x%04x: %s\n", desc.idVendor, desc.idProduct, libusb_strerror(len));
+                            }
+                            if(shellStyleMatch(serial, serialNamePattern)){
+                                if(printMatchingDevicesFp != NULL){
+                                    if(serial[0] == 0){
+                                        fprintf(printMatchingDevicesFp, "VID=0x%04x PID=0x%04x vendor=\"%s\" product=\"%s\"\n", desc.idVendor, desc.idProduct, vendor, product);
                                     }else{
-                                        break;
+                                        fprintf(printMatchingDevicesFp, "VID=0x%04x PID=0x%04x vendor=\"%s\" product=\"%s\" serial=\"%s\"\n", desc.idVendor, desc.idProduct, vendor, product, serial);
                                     }
+                                }else{
+                                    break;
                                 }
                             }
                         }
                     }
                 }
-                usb_close(handle);
-                handle = NULL;
             }
+        libusb_close(dev_handle);
         }
-        if(handle)  /* we have found a deice */
-            break;
     }
-    if(handle != NULL){
+
+out:
+    libusb_free_device_list(devs, 1);
+
+    if(dev_handle != NULL){
         errorCode = 0;
-        *device = handle;
+        *device = dev_handle;
     }
     if(printMatchingDevicesFp != NULL)  /* never return an error for listing only */
         errorCode = 0;

--- a/libs-host/opendevice.c
+++ b/libs-host/opendevice.c
@@ -88,7 +88,7 @@ char    buffer[256];
 int     rval, i;
 
     rval = libusb_get_string_descriptor_ascii(dev, index, (unsigned char *)buf, buflen); /* use libusb version if it works */
-    if(rval < 0)
+    if(rval >= 0)
         return rval;
     if((rval = libusb_control_transfer(dev, LIBUSB_ENDPOINT_IN, LIBUSB_REQUEST_GET_DESCRIPTOR, (LIBUSB_DT_STRING << 8) + index, 0, (unsigned char *)buffer, sizeof(buffer), 5000)) < 0)
         return rval;

--- a/libs-host/opendevice.h
+++ b/libs-host/opendevice.h
@@ -22,10 +22,10 @@ files according to the GNU General Public License (GPL) version 2 or 3.
 #ifndef __OPENDEVICE_H_INCLUDED__
 #define __OPENDEVICE_H_INCLUDED__
 
-#include <usb.h>    /* this is libusb, see http://libusb.sourceforge.net/ */
+#include <libusb.h>    /* this is libusb, see http://libusb.sourceforge.net/ */
 #include <stdio.h>
 
-int usbGetStringAscii(usb_dev_handle *dev, int index, char *buf, int buflen);
+int usbGetStringAscii(libusb_device_handle *dev, int index, char *buf, int buflen);
 /* This function gets a string descriptor from the device. 'index' is the
  * string descriptor index. The string is returned in ISO Latin 1 encoding in
  * 'buf' and it is terminated with a 0-character. The buffer size must be
@@ -36,7 +36,7 @@ int usbGetStringAscii(usb_dev_handle *dev, int index, char *buf, int buflen);
  * usb_strerror() to obtain the error message.
  */
 
-int usbOpenDevice(usb_dev_handle **device, int vendorID, char *vendorNamePattern, int productID, char *productNamePattern, char *serialNamePattern, FILE *printMatchingDevicesFp, FILE *warningsFp);
+int usbOpenDevice(libusb_device_handle **device, int vendorID, char *vendorNamePattern, int productID, char *productNamePattern, char *serialNamePattern, FILE *printMatchingDevicesFp, FILE *warningsFp);
 /* This function iterates over all devices on all USB busses and searches for
  * a device. Matching is done first by means of Vendor- and Product-ID (passed
  * in 'vendorID' and 'productID'. An ID of 0 matches any numeric ID (wildcard).
@@ -54,7 +54,7 @@ int usbOpenDevice(usb_dev_handle **device, int vendorID, char *vendorNamePattern
  * 'printMatchingDevicesFp' is not NULL, no device is opened but matching
  * devices are printed to the given file descriptor with fprintf().
  * If a device is opened, the resulting USB handle is stored in '*device'. A
- * pointer to a "usb_dev_handle *" type variable must be passed here.
+ * pointer to a "libusb_device_handle *" type variable must be passed here.
  * Returns: 0 on success, an error code (see defines below) on failure.
  */
 

--- a/libs-host/opendevice.h
+++ b/libs-host/opendevice.h
@@ -33,7 +33,7 @@ int usbGetStringAscii(libusb_device_handle *dev, int index, char *buf, int bufle
  * must be given in 'dev'.
  * Returns: The length of the string (excluding the terminating 0) or
  * a negative number in case of an error. If there was an error, use
- * usb_strerror() to obtain the error message.
+ * libusb_strerror() to obtain the error message.
  */
 
 int usbOpenDevice(libusb_device_handle **device, int vendorID, char *vendorNamePattern, int productID, char *productNamePattern, char *serialNamePattern, FILE *printMatchingDevicesFp, FILE *warningsFp);


### PR DESCRIPTION
This updates the host libraries and tools to use libusb-1.0 instead of libusb-0.1 as
version 0.1 is deprecated and no longer provided as a package in many recent
Linux distributions.

The changes were tested on Ubuntu 20.04 and Windows 10 Version 2004.
I do not have a macOS System available so I could not test that.

To be able to build and run the drivertest example on Linux I also had to include the fix
for issue #11, therefore this pull request would also close that issue.
Other than that I tried to keep the changes as minimal as possible and to not introduce
stylistic changes or changes to the behavior of any tools and libraries.

The target software is not affected by the changes in this pull request.