### PR TITLE
Adjust usbdrvasm16.inc to support AVR 1-series.

### DIFF
--- a/usbdrv/usbdrv.c
+++ b/usbdrv/usbdrv.c
@@ -29,6 +29,7 @@ uchar       usbCurrentTok;      /* last token received or endpoint number for la
 uchar       usbRxToken;         /* token for data we received; or endpont number for last OUT */
 volatile uchar usbTxLen = USBPID_NAK;   /* number of bytes to transmit with next IN token or handshake token */
 uchar       usbTxBuf[USB_BUFSIZE];/* data to transmit with next IN, free if usbTxLen contains handshake token */
+uchar       usbTxToken;
 #if USB_COUNT_SOF
 volatile uchar  usbSofCount;    /* incremented by assembler module every SOF */
 #endif

--- a/usbdrv/usbdrv.h
+++ b/usbdrv/usbdrv.h
@@ -531,11 +531,12 @@ int usbDescriptorStringSerialNumber[];
 /* ------------------------------------------------------------------------- */
 
 #define USB_CONCAT(a, b)            a ## b
+#define USB_CONCAT3(a, b, c)        a ## b ## c
 #define USB_CONCAT_EXPANDED(a, b)   USB_CONCAT(a, b)
 
-#define USB_OUTPORT(name)           USB_CONCAT(PORT, name)
-#define USB_INPORT(name)            USB_CONCAT(PIN, name)
-#define USB_DDRPORT(name)           USB_CONCAT(DDR, name)
+#define USB_OUTPORT(name)           USB_CONCAT3(VPORT, name, _OUT)
+#define USB_INPORT(name)            USB_CONCAT3(VPORT, name, _IN)
+#define USB_DDRPORT(name)           USB_CONCAT3(VPORT, name, _DIR)
 /* The double-define trick above lets us concatenate strings which are
  * defined by macros.
  */

--- a/usbdrv/usbdrvasm.S
+++ b/usbdrv/usbdrvasm.S
@@ -34,7 +34,7 @@ the file appropriate for the given clock rate.
 
 #ifdef __IAR_SYSTEMS_ASM__
     extern  usbRxBuf, usbDeviceAddr, usbNewDeviceAddr, usbInputBufOffset
-    extern  usbCurrentTok, usbRxLen, usbRxToken, usbTxLen
+    extern  usbCurrentTok, usbRxLen, usbRxToken, usbTxLen, usbTxToken
     extern  usbTxBuf, usbTxStatus1, usbTxStatus3
 #   if USB_COUNT_SOF
         extern usbSofCount

--- a/usbdrv/usbdrvasm16.inc
+++ b/usbdrv/usbdrvasm16.inc
@@ -24,6 +24,15 @@ really know what you are doing! Many parts require not only a maximum number
 of CPU cycles, but even an exact number of cycles!
 */
 
+/*
+Timing differences between the original ASM and the attiny1614:
+
+PUSH: is 1 cycle, this code assumes 2 cycles, so add one NOP
+ST with increment: is 1 cycle, this code assumes 2 cycles, so add one NOP
+SBI: is 1 cycle, this code assumes 2 cycles, so add one NOP
+LDS: is 3 cycles, this code assumes 2 cycles, so save one cycle somewhere else
+*/
+
 ;max stack usage: [ret(2), YL, SREG, YH, bitcnt, shift, x1, x2, x3, x4, cnt] = 12 bytes
 ;nominal frequency: 16 MHz -> 10.6666666 cycles per bit, 85.333333333 cycles per byte
 ; Numbers in brackets are clocks counted from center of last sync bit
@@ -32,9 +41,12 @@ of CPU cycles, but even an exact number of cycles!
 USB_INTR_VECTOR:
 ;order of registers pushed: YL, SREG YH, [sofError], bitcnt, shift, x1, x2, x3, x4, cnt
     push    YL                  ;[-25] push only what is necessary to sync with edge ASAP
+    nop
     in      YL, SREG            ;[-23]
     push    YL                  ;[-22]
+    nop
     push    YH                  ;[-20]
+    nop
 ;----------------------------------------------------------------------------
 ; Synchronize with sync pattern:
 ;----------------------------------------------------------------------------
@@ -75,14 +87,16 @@ foundK:                         ;[-12]
 ;we have 1 bit time for setup purposes, then sample again. Numbers in brackets
 ;are cycles from center of first sync (double K) bit after the instruction
     push    bitcnt              ;[-12]
+    nop
 ;   [---]                       ;[-11]
     lds     YL, usbInputBufOffset;[-10]
 ;   [---]                       ;[-9]
-    clr     YH                  ;[-8]
-    subi    YL, lo8(-(usbRxBuf));[-7] [rx loop init]
-    sbci    YH, hi8(-(usbRxBuf));[-6] [rx loop init]
-    push    shift               ;[-5]
-;   [---]                       ;[-4]
+;   [---]                       ;[-8]
+    clr     YH                  ;[-7]
+    subi    YL, lo8(-(usbRxBuf));[-6] [rx loop init]
+    sbci    YH, hi8(-(usbRxBuf));[-5] [rx loop init]
+    push    shift               ;[-4]
+    ; no nop on 1-series to correct lds taking 1 cycle longer earlier
     ldi     bitcnt, 0x55        ;[-3] [rx loop init]
     sbis    USBIN, USBMINUS     ;[-2] we want two bits K (sample 2 cycles too early)
     rjmp    haveTwoBitsK        ;[-1]
@@ -97,17 +111,22 @@ foundK:                         ;[-12]
 ;----------------------------------------------------------------------------
 haveTwoBitsK:
     push    x1              ;[1]
+    nop
     push    x2              ;[3]
+    nop
     push    x3              ;[5]
+    nop
     ldi     shift, 0        ;[7]
     ldi     x3, 1<<4        ;[8] [rx loop init] first sample is inverse bit, compensate that
     push    x4              ;[9] == leap
+    nop
 
     in      x1, USBIN       ;[11] <-- sample bit 0
     andi    x1, USBMASK     ;[12]
     bst     x1, USBMINUS    ;[13]
     bld     shift, 7        ;[14]
     push    cnt             ;[15]
+    nop
     ldi     leap, 0         ;[17] [rx loop init]
     ldi     cnt, USB_BUFSIZE;[18] [rx loop init]
     rjmp    rxbit1          ;[19] arrives at [21]
@@ -178,6 +197,7 @@ didUnstuff7:
     brcc    unstuff7    ;[07]
     eor     x3, shift   ;[08] reconstruct: x3 is 1 at bit locations we changed, 0 at others
     st      y+, x3      ;[09] store data
+    nop
 rxBitLoop:
     in      x1, USBIN   ;[00] [11] <-- sample bit 0/2/4
     andi    x1, USBMASK ;[01]
@@ -253,16 +273,20 @@ bitstuff7:
 
 sendNakAndReti:
     ldi     x3, USBPID_NAK  ;[-18]
-    rjmp    sendX3AndReti   ;[-17]
+    ldi     YL, lo8(usbTxToken) ;[-17]
+    ldi     YH, hi8(usbTxToken) ;[-16]
+    st      y, x3           ;[-15]
+    rjmp    usbSendAndReti  ;[-14]
 sendAckAndReti:
     ldi     cnt, USBPID_ACK ;[-17]
 sendCntAndReti:
-    mov     x3, cnt         ;[-16]
-sendX3AndReti:
-    ldi     YL, 20          ;[-15] x3==r20 address is 20
-    ldi     YH, 0           ;[-14]
+    ldi     YL, lo8(usbTxToken)  ;[-16]
+    ldi     YH, hi8(usbTxToken) ;[-15]
+    st      y, cnt          ;[-14]
     ldi     cnt, 2          ;[-13]
 ;   rjmp    usbSendAndReti      fallthrough
+
+
 
 ;usbSend:
 ;pointer to data in 'Y'
@@ -275,6 +299,7 @@ usbSendAndReti:             ; 12 cycles until SOP
     in      x2, USBDDR      ;[-12]
     ori     x2, USBMASK     ;[-11]
     sbi     USBOUT, USBMINUS;[-10] prepare idle state; D+ and D- must have been 0 (no pullups)
+    nop
     in      x1, USBOUT      ;[-8] port mirror for tx loop
     out     USBDDR, x2      ;[-7] <- acquire bus
 ; need not init x2 (bitstuff history) because sync starts with 0
@@ -318,28 +343,28 @@ didStuff7:
 ;make SE0:
     cbr     x1, USBMASK     ;[5] prepare SE0 [spec says EOP may be 21 to 25 cycles]
     lds     x2, usbNewDeviceAddr;[6]
-    lsl     x2              ;[8] we compare with left shifted address
-    subi    YL, 20 + 2      ;[9] Only assign address on data packets, not ACK/NAK in x3
-    sbci    YH, 0           ;[10]
-    out     USBOUT, x1      ;[11] <-- out SE0 -- from now 2 bits = 22 cycles until bus idle
+    lsl     x2              ;[9] we compare with left shifted address
+    subi    YL, 20 + 2      ;[10] Only assign address on data packets, not ACK/NAK in x3
+    sbci    YH, 0           ;[0] [11]
+    out     USBOUT, x1      ;[1] <-- out SE0 -- from now 2 bits = 22 cycles until bus idle
 ;2006-03-06: moved transfer of new address to usbDeviceAddr from C-Code to asm:
 ;set address only after data packet was sent, not after handshake
-    breq    skipAddrAssign  ;[0]
+    breq    skipAddrAssign  ;[2]
     sts     usbDeviceAddr, x2; if not skipped: SE0 is one cycle longer
 skipAddrAssign:
 ;end of usbDeviceAddress transfer
-    ldi     x2, 1<<USB_INTR_PENDING_BIT;[2] int0 occurred during TX -- clear pending flag
-    USB_STORE_PENDING(x2)   ;[3]
-    ori     x1, USBIDLE     ;[4]
-    in      x2, USBDDR      ;[5]
-    cbr     x2, USBMASK     ;[6] set both pins to input
-    mov     x3, x1          ;[7]
-    cbr     x3, USBMASK     ;[8] configure no pullup on both pins
-    ldi     x4, 4           ;[9]
+    ldi     x2, 1<<USB_INTR_PENDING_BIT;[3] int0 occurred during TX -- clear pending flag
+    USB_STORE_PENDING(x2)   ;[4]
+    ori     x1, USBIDLE     ;[5]
+    in      x2, USBDDR      ;[6]
+    cbr     x2, USBMASK     ;[7] set both pins to input
+    mov     x3, x1          ;[8]
+    cbr     x3, USBMASK     ;[9] configure no pullup on both pins
+    ldi     x4, 4           ;[10]
 se0Delay:
-    dec     x4              ;[10] [13] [16] [19]
-    brne    se0Delay        ;[11] [14] [17] [20]
-    out     USBOUT, x1      ;[21] <-- out J (idle) -- end of SE0 (EOP signal)
-    out     USBDDR, x2      ;[22] <-- release bus now
-    out     USBOUT, x3      ;[23] <-- ensure no pull-up resistors are active
+    dec     x4              ;[11] [14] [17] [20]
+    brne    se0Delay        ;[12] [15] [18] [21]
+    out     USBOUT, x1      ;[22] <-- out J (idle) -- end of SE0 (EOP signal)
+    out     USBDDR, x2      ;[23] <-- release bus now
+    out     USBOUT, x3      ;[24] <-- ensure no pull-up resistors are active
     rjmp    doReturn


### PR DESCRIPTION
Tested on attiny1614. **Can't be merged immediately, since it would break usbdrvasm16 for older AVR devices, so this is a first version.** I'm mostly putting this here as to allow other people to work with the code on their 1-series AVR device. If you'd like to merge this, I will spend additional time to get the patch into mergeable state, but didn't want to start on that before hearing your intentions :-)

###  Usage instructions

#### Clock speed

16 MHz is the only supported clock speed that can be produced by the internal oscillator, at least on my attiny1614, so this PR only updates the 16MHz-clocked version of the code (`usbdrvasm16.inc`). To set your AVR to 16 MHz, you need to set the `FUSE_OSCCFG` to `FREQSEL_16MHZ_gc`. Be careful doing this, since setting the wrong fuses can brick your device. For my device, I read the fuses using `pyupdi -d tiny1614 -c /dev/tty.usbserial -fr`, where fuse 2 (`OSCCFG`) was set to 0x02, meaning 20 MHz. I cleared bit 2 and set bit 1, so the value becomes 0x01 i.e. 16 MHz, using `pyupdi -d tiny1614 -c /dev/tty.usbserial -fs 2:0x01`. Check your datasheet before doing this! After setting the fuse, you need to disable the prescaler inside your firmware. My firmware starts with this:

```
// Disable the clock prescaler so that we are running at 16 MHz or 20 MHz
_PROTECTED_WRITE(CLKCTRL_MCLKCTRLB, 0);

// Confirm that 16 MHz clock is selected in fuses.
if ((FUSE_OSCCFG & FUSE_FREQSEL_gm) != FRESQL_16MHZ_gc) {
  led_fatal();
}
```

where `led_fatal()` makes a LED blink really fast to indicate error state.

#### GPIO pins

I connected the USB D- to PB0, which is pin 9, and D+ to PB1, which is pin 8. A hint for when you're just starting out: USB cable coloring is **not consistent between cables**, so don't look only at the cable colors when connecting everything up. To make my device USB low-speed compliant, I have a 1.5 kOhm resistor between D- and Vcc. Also, I have a 1MOhm resistor between D+ and Vcc so it doesn't float when no host is connected.

#### usbInit

Then, I don't use `usbInit()` to initialize my GPIO pins, since it seemed harder to get this function to do the right thing generically than to just do it myself for now. V-USB supports interrupt on both D- and D+, but the recommended interrupt is on the rising edge of D+ (in my case, PB1), so:

```
    // instead of usbInit():
    PORTB.DIRCLR = (1 << 1);
    PORTB.DIRCLR = (1 << 0);
    PORTB.PIN0CTRL = 0;
    PORTB.PIN1CTRL = PORT_ISC_RISING_gc;
    PORTB.PIN2CTRL = 0;
    PORTB.PIN3CTRL = 0;
    PORTB.PIN4CTRL = 0;
    PORTB.PIN5CTRL = 0;
    PORTB.PIN6CTRL = 0;
    PORTB.PIN7CTRL = 0;

    usbDeviceDisconnect();
    _delay_ms(250);
    usbDeviceConnect();

    sei();
    while (1)
    {
        wdt_reset();
        usbPoll();
    }
```

#### usbconfig.h

The following settings are important in `usbconfig.h`:

- Start with the default `v-usb/usbdrv/usbconfig-prototype.h`
- `USB_CFG_IOPORTNAME` is `B` in my case
- `USB_CFG_DMINUS_BIT` & `USB_CFG_DPLUS_BIT` are `0` and `1` in my case
- You should set `F_CPU` to 16000000 (see above), so `USB_CFG_CLOCK_KHZ` can remain defined as `(F_CPU/1000)`
- `USB_CFG_CHECK_CRC` must be 0, since there's no time to check the CRC
- `USB_INTR_CFG*` and `USB_INTR_ENABLE*` are only used in `usbInit`, so we don't use that
- `USB_INTR_PENDING` must be set to `VPORTB_INTFLAGS` (or another `VPORT` if you don't use port B)
- `USB_INTR_PENDING_BIT` in my case is set to `VPORT_INT1_bp` meaning the bit position of pin 1, together with the previous option this means the assembly will read/write the interrupt pending bit for pin PB1 (D+), where we actually have the interrupt set
- `USB_INTR_VECTOR` is set to `PORTB_PORT_vect`, the interrupt vector for port B. This is translated to `__vector_4`.
- Do go through the options in the entire file yourself as well, and modify options as indicated.

### Thanks

I'd like to shout out to the author of http://www.usbmadesimple.co.uk/, whose documentation was invaluable while writing this patch. Also, thanks to the authors of V-USB, since the code is quite clear and well-written.